### PR TITLE
Add description to POM files, minor README changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 ## Declarative Pipeline Migration Assistant 
 
 [![Jenkins Plugin](https://img.shields.io/jenkins/plugin/v/declarative-pipeline-migration-assistant)](https://plugins.jenkins.io/declarative-pipeline-migration-assistant)
-[![Changelog](https://img.shields.io/github/v/tag/jenkinsci/convert-to-declarative?label=changelog)](https://github.com/jenkinsci/convert-to-declarative/blob/master/CHANGELOG.md)
+[![Changelog](https://img.shields.io/github/v/tag/jenkinsci/convert-to-declarative?label=changelog)](https://github.com/jenkinsci/declarative-pipeline-migration-assistant-plugin/releases)
 [![Jenkins Plugin Installs](https://img.shields.io/jenkins/plugin/i/declarative-pipeline-migration-assistant?color=blue)](https://plugins.jenkins.io/declarative-pipeline-migration-assistant)
-[![Contributors](https://img.shields.io/github/contributors/jenkinsci/declarative-pipeline-migration-assistant.svg)](https://github.com/jenkinsci/convert-to-declarative/contributors)
+[![Contributors](https://img.shields.io/github/contributors/jenkinsci/declarative-pipeline-migration-assistant.svg)](https://github.com/jenkinsci/declarative-pipeline-migration-assistant/contributors)
 This project includes a plugin that uses details from a Freestyle project to generate a starting Jenkinsfile.The Declarative Pipeline Migration Assistant plugin uses a “best effort” approach during generation, which means supported configurations in Freestyle projects will be automatically converted, and placeholder stages will be created for plugins that are not yet supported.
 
 There are two modules in the project:

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Jenkins Plugin](https://img.shields.io/jenkins/plugin/v/declarative-pipeline-migration-assistant)](https://plugins.jenkins.io/declarative-pipeline-migration-assistant)
 [![Changelog](https://img.shields.io/github/v/tag/jenkinsci/convert-to-declarative?label=changelog)](https://github.com/jenkinsci/declarative-pipeline-migration-assistant-plugin/releases)
-[![Jenkins Plugin Installs](https://img.shields.io/jenkins/plugin/i/declarative-pipeline-migration-assistant?color=blue)](https://plugins.jenkins.io/github-branch-source)
+[![Jenkins Plugin Installs](https://img.shields.io/jenkins/plugin/i/declarative-pipeline-migration-assistant?color=blue)](https://plugins.jenkins.io/declarative-pipeline-migration-assistant)
 [![Contributors](https://img.shields.io/github/contributors/jenkinsci/convert-to-declarative.svg)](https://github.com/jenkinsci/declarative-pipeline-migration-assistant-plugin/graphs/contributors)
 
 This project includes a plugin that uses details from a Freestyle project to generate a starting Jenkinsfile. The Declarative Pipeline Migration Assistant plugin uses a “best effort” approach during generation, which means supported configurations in Freestyle projects will be automatically converted, and placeholder stages will be created for plugins that are not yet supported.

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 ## Declarative Pipeline Migration Assistant 
 
 [![Jenkins Plugin](https://img.shields.io/jenkins/plugin/v/declarative-pipeline-migration-assistant)](https://plugins.jenkins.io/declarative-pipeline-migration-assistant)
-[![Changelog](https://img.shields.io/github/v/tag/jenkinsci/convert-to-declarative?label=changelog)](https://github.com/jenkinsci/convert-to-declarative/releases)
+[![Changelog](https://img.shields.io/github/v/tag/jenkinsci/declarative-pipeline-migration-assistant?label=changelog)](https://github.com/jenkinsci/declarative-pipeline-migration-assistant-plugin/releases)
 [![Jenkins Plugin Installs](https://img.shields.io/jenkins/plugin/i/declarative-pipeline-migration-assistant?color=blue)](https://plugins.jenkins.io/convert-to-declarative)
-[![Contributors](https://img.shields.io/github/contributors/jenkinsci/declarative-pipeline-migration-assistant.svg)](https://github.com/jenkinsci/convert-to-declarative/contributors)
+[![Contributors](https://img.shields.io/github/contributors/jenkinsci/declarative-pipeline-migration-assistant.svg)](https://github.com/jenkinsci/declarative-pipeline-migration-assistant-plugin/graphs/contributors)
 This project includes a plugin that uses details from a Freestyle project to generate a starting Jenkinsfile.The Declarative Pipeline Migration Assistant plugin uses a “best effort” approach during generation, which means supported configurations in Freestyle projects will be automatically converted, and placeholder stages will be created for plugins that are not yet supported.
 
 There are two modules in the project:

--- a/README.md
+++ b/README.md
@@ -1,16 +1,18 @@
 ## Declarative Pipeline Migration Assistant 
 
 [![Jenkins Plugin](https://img.shields.io/jenkins/plugin/v/declarative-pipeline-migration-assistant)](https://plugins.jenkins.io/declarative-pipeline-migration-assistant)
-[![Changelog](https://img.shields.io/github/v/tag/jenkinsci/declarative-pipeline-migration-assistant?label=changelog)](https://github.com/jenkinsci/declarative-pipeline-migration-assistant-plugin/releases)
-[![Jenkins Plugin Installs](https://img.shields.io/jenkins/plugin/i/declarative-pipeline-migration-assistant?color=blue)](https://plugins.jenkins.io/convert-to-declarative)
-[![Contributors](https://img.shields.io/github/contributors/jenkinsci/declarative-pipeline-migration-assistant.svg)](https://github.com/jenkinsci/declarative-pipeline-migration-assistant-plugin/graphs/contributors)
-This project includes a plugin that uses details from a Freestyle project to generate a starting Jenkinsfile.The Declarative Pipeline Migration Assistant plugin uses a “best effort” approach during generation, which means supported configurations in Freestyle projects will be automatically converted, and placeholder stages will be created for plugins that are not yet supported.
+[![Changelog](https://img.shields.io/github/v/tag/jenkinsci/convert-to-declarative?label=changelog)](https://github.com/jenkinsci/declarative-pipeline-migration-assistant-plugin/releases)
+[![Jenkins Plugin Installs](https://img.shields.io/jenkins/plugin/i/declarative-pipeline-migration-assistant?color=blue)](https://plugins.jenkins.io/github-branch-source)
+[![Contributors](https://img.shields.io/github/contributors/jenkinsci/convert-to-declarative.svg)](https://github.com/jenkinsci/declarative-pipeline-migration-assistant-plugin/graphs/contributors)
+
+This project includes a plugin that uses details from a Freestyle project to generate a starting Jenkinsfile. The Declarative Pipeline Migration Assistant plugin uses a “best effort” approach during generation, which means supported configurations in Freestyle projects will be automatically converted, and placeholder stages will be created for plugins that are not yet supported.
 
 There are two modules in the project:
 - The plugin which uses the API to generate a Jenkinsfile based on a Freestyle project
 - The API (the base of extension points to convert different parts of a Freestyle project)
 
-Documentation for this plugin is hosted on [https://docs.cloudbees.com/docs/admin-resources/latest/pipelines-user-guide/declarative-pipeline-migration-assistant](the Cloudbees documentation site).
+Documentation for this plugin is hosted on 
+[the CloudBees documentation site](https://docs.cloudbees.com/docs/admin-resources/latest/pipelines-user-guide/declarative-pipeline-migration-assistant).
 
 ### The plugin
 For further details on using the plugin, please see Converting a Freestyle project to a Declarative Pipeline.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 ## Declarative Pipeline Migration Assistant 
 
+[![Jenkins Plugin](https://img.shields.io/jenkins/plugin/v/declarative-pipeline-migration-assistant)](https://plugins.jenkins.io/declarative-pipeline-migration-assistant)
+[![Changelog](https://img.shields.io/github/v/tag/jenkinsci/declarative-pipeline-migration-assistant?label=changelog)](https://github.com/jenkinsci/declarative-pipeline-migration-assistant-plugin/releases)
+[![Jenkins Plugin Installs](https://img.shields.io/jenkins/plugin/i/declarative-pipeline-migration-assistant?color=blue)](https://plugins.jenkins.io/convert-to-declarative)
+[![Contributors](https://img.shields.io/github/contributors/jenkinsci/declarative-pipeline-migration-assistant.svg)](https://github.com/jenkinsci/declarative-pipeline-migration-assistant-plugin/graphs/contributors)
 This project includes a plugin that uses details from a Freestyle project to generate a starting Jenkinsfile.The Declarative Pipeline Migration Assistant plugin uses a “best effort” approach during generation, which means supported configurations in Freestyle projects will be automatically converted, and placeholder stages will be created for plugins that are not yet supported.
 
 There are two modules in the project:

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 ## Declarative Pipeline Migration Assistant 
 
 [![Jenkins Plugin](https://img.shields.io/jenkins/plugin/v/declarative-pipeline-migration-assistant)](https://plugins.jenkins.io/declarative-pipeline-migration-assistant)
-[![Changelog](https://img.shields.io/github/v/tag/jenkinsci/declarative-pipeline-migration-assistant?label=changelog)](https://github.com/jenkinsci/declarative-pipeline-migration-assistant/blob/master/CHANGELOG.md)
+[![Changelog](https://img.shields.io/github/v/tag/jenkinsci/convert-to-declarative?label=changelog)](https://github.com/jenkinsci/convert-to-declarative/blob/master/CHANGELOG.md)
 [![Jenkins Plugin Installs](https://img.shields.io/jenkins/plugin/i/declarative-pipeline-migration-assistant?color=blue)](https://plugins.jenkins.io/declarative-pipeline-migration-assistant)
-[![Contributors](https://img.shields.io/github/contributors/jenkinsci/declarative-pipeline-migration-assistant.svg)](https://github.com/jenkinsci/declarative-pipeline-migration-assistant/contributors)
+[![Contributors](https://img.shields.io/github/contributors/jenkinsci/declarative-pipeline-migration-assistant.svg)](https://github.com/jenkinsci/convert-to-declarative/contributors)
 This project includes a plugin that uses details from a Freestyle project to generate a starting Jenkinsfile.The Declarative Pipeline Migration Assistant plugin uses a “best effort” approach during generation, which means supported configurations in Freestyle projects will be automatically converted, and placeholder stages will be created for plugins that are not yet supported.
 
 There are two modules in the project:

--- a/README.md
+++ b/README.md
@@ -1,9 +1,5 @@
 ## Declarative Pipeline Migration Assistant 
 
-[![Jenkins Plugin](https://img.shields.io/jenkins/plugin/v/declarative-pipeline-migration-assistant)](https://plugins.jenkins.io/declarative-pipeline-migration-assistant)
-[![Changelog](https://img.shields.io/github/v/tag/jenkinsci/declarative-pipeline-migration-assistant?label=changelog)](https://github.com/jenkinsci/declarative-pipeline-migration-assistant-plugin/releases)
-[![Jenkins Plugin Installs](https://img.shields.io/jenkins/plugin/i/declarative-pipeline-migration-assistant?color=blue)](https://plugins.jenkins.io/convert-to-declarative)
-[![Contributors](https://img.shields.io/github/contributors/jenkinsci/declarative-pipeline-migration-assistant.svg)](https://github.com/jenkinsci/declarative-pipeline-migration-assistant-plugin/graphs/contributors)
 This project includes a plugin that uses details from a Freestyle project to generate a starting Jenkinsfile.The Declarative Pipeline Migration Assistant plugin uses a “best effort” approach during generation, which means supported configurations in Freestyle projects will be automatically converted, and placeholder stages will be created for plugins that are not yet supported.
 
 There are two modules in the project:

--- a/README.md
+++ b/README.md
@@ -1,11 +1,16 @@
 ## Declarative Pipeline Migration Assistant 
+
+[![Jenkins Plugin](https://img.shields.io/jenkins/plugin/v/declarative-pipeline-migration-assistant)](https://plugins.jenkins.io/declarative-pipeline-migration-assistant)
+[![Changelog](https://img.shields.io/github/v/tag/jenkinsci/declarative-pipeline-migration-assistant?label=changelog)](https://github.com/jenkinsci/declarative-pipeline-migration-assistant/blob/master/CHANGELOG.md)
+[![Jenkins Plugin Installs](https://img.shields.io/jenkins/plugin/i/declarative-pipeline-migration-assistant?color=blue)](https://plugins.jenkins.io/declarative-pipeline-migration-assistant)
+[![Contributors](https://img.shields.io/github/contributors/jenkinsci/declarative-pipeline-migration-assistant.svg)](https://github.com/jenkinsci/declarative-pipeline-migration-assistant/contributors)
 This project includes a plugin that uses details from a Freestyle project to generate a starting Jenkinsfile.The Declarative Pipeline Migration Assistant plugin uses a “best effort” approach during generation, which means supported configurations in Freestyle projects will be automatically converted, and placeholder stages will be created for plugins that are not yet supported.
 
 There are two modules in the project:
 - The plugin which uses the API to generate a Jenkinsfile based on a Freestyle project
 - The API (the base of extension points to convert different parts of a Freestyle project)
 
-You can find more documentation on the Cloudbees documentation site [http://cloudbees.com/r/declarative-pipeline-migration-assistant](http://cloudbees.com/r/declarative-pipeline-migration-assistant)
+Documentation for this plugin is hosted on [https://docs.cloudbees.com/docs/admin-resources/latest/pipelines-user-guide/declarative-pipeline-migration-assistant](the Cloudbees documentation site).
 
 ### The plugin
 For further details on using the plugin, please see Converting a Freestyle project to a Declarative Pipeline.

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 ## Declarative Pipeline Migration Assistant 
 
 [![Jenkins Plugin](https://img.shields.io/jenkins/plugin/v/declarative-pipeline-migration-assistant)](https://plugins.jenkins.io/declarative-pipeline-migration-assistant)
-[![Changelog](https://img.shields.io/github/v/tag/jenkinsci/convert-to-declarative?label=changelog)](https://github.com/jenkinsci/declarative-pipeline-migration-assistant-plugin/releases)
-[![Jenkins Plugin Installs](https://img.shields.io/jenkins/plugin/i/declarative-pipeline-migration-assistant?color=blue)](https://plugins.jenkins.io/declarative-pipeline-migration-assistant)
-[![Contributors](https://img.shields.io/github/contributors/jenkinsci/declarative-pipeline-migration-assistant.svg)](https://github.com/jenkinsci/declarative-pipeline-migration-assistant/contributors)
+[![Changelog](https://img.shields.io/github/v/tag/jenkinsci/convert-to-declarative?label=changelog)](https://github.com/jenkinsci/convert-to-declarative/releases)
+[![Jenkins Plugin Installs](https://img.shields.io/jenkins/plugin/i/declarative-pipeline-migration-assistant?color=blue)](https://plugins.jenkins.io/convert-to-declarative)
+[![Contributors](https://img.shields.io/github/contributors/jenkinsci/declarative-pipeline-migration-assistant.svg)](https://github.com/jenkinsci/convert-to-declarative/contributors)
 This project includes a plugin that uses details from a Freestyle project to generate a starting Jenkinsfile.The Declarative Pipeline Migration Assistant plugin uses a “best effort” approach during generation, which means supported configurations in Freestyle projects will be automatically converted, and placeholder stages will be created for plugins that are not yet supported.
 
 There are two modules in the project:

--- a/declarative-pipeline-migration-assistant-api/pom.xml
+++ b/declarative-pipeline-migration-assistant-api/pom.xml
@@ -10,7 +10,7 @@
   <version>1.0.1-SNAPSHOT</version>
   <packaging>hpi</packaging>
   <name>Declarative Pipeline Migration Assistant API</name>
-  <description>TODO</description>
+  <description>Extension points to convert different parts of a Freestyle project</description>
 
   <dependencies>
     <dependency>

--- a/declarative-pipeline-migration-assistant-api/pom.xml
+++ b/declarative-pipeline-migration-assistant-api/pom.xml
@@ -10,7 +10,7 @@
   <version>1.0.1-SNAPSHOT</version>
   <packaging>hpi</packaging>
   <name>Declarative Pipeline Migration Assistant API</name>
-  <description>Extension points to convert different parts of a Freestyle project</description>
+  <description>Declarative Pipeline Migration Assistant API (this plugin contains APIs used to convert Freestyle Jobs into Declarative Pipelines).</description>
 
   <dependencies>
     <dependency>

--- a/declarative-pipeline-migration-assistant-api/src/main/resources/index.jelly
+++ b/declarative-pipeline-migration-assistant-api/src/main/resources/index.jelly
@@ -1,4 +1,4 @@
 <?jelly escape-by-default='true'?>
 <div>
-    Declarative Pipeline Migration Assistant API (this plugin contains API used to convert jobs to declarative pipeline).
+    Declarative Pipeline Migration Assistant API (this plugin contains APIs used to convert Freestyle Jobs into Declarative Pipelines).
 </div>

--- a/declarative-pipeline-migration-assistant/pom.xml
+++ b/declarative-pipeline-migration-assistant/pom.xml
@@ -10,7 +10,7 @@
   <version>1.0.1-SNAPSHOT</version>
   <packaging>hpi</packaging>
   <name>Declarative Pipeline Migration Assistant</name>
-  <description>The plugin which uses the API to generate a Jenkinsfile based on a Freestyle project</description>
+  <description>Declarative Pipeline Migration Assistant Plugin.</description>
 
   <dependencies>
     <dependency>

--- a/declarative-pipeline-migration-assistant/pom.xml
+++ b/declarative-pipeline-migration-assistant/pom.xml
@@ -10,6 +10,7 @@
   <version>1.0.1-SNAPSHOT</version>
   <packaging>hpi</packaging>
   <name>Declarative Pipeline Migration Assistant</name>
+  <description>The plugin which uses the API to generate a Jenkinsfile based on a Freestyle project</description>
 
   <dependencies>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
   <version>1.0.1-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>Declarative Pipeline Migration Assistant</name>
-  <description>A plugin which converts existing Freestyle project into a starter Declarative Jenkinsfile</description>
+  <description>Declarative Pipeline Migration Assistant Plugin.</description>
 
   <url>https://github.com/jenkinsci/declarative-pipeline-migration-assistant-plugin</url>
 

--- a/pom.xml
+++ b/pom.xml
@@ -37,6 +37,7 @@
   <version>1.0.1-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>Declarative Pipeline Migration Assistant</name>
+  <description>A plugin which converts existing Freestyle project into a starter Declarative Jenkinsfile</description>
 
   <url>https://github.com/jenkinsci/declarative-pipeline-migration-assistant-plugin</url>
 


### PR DESCRIPTION
This PR adds `<description>`s to the plugins' pom.xml files. This should help the plugin's description show up in the "Available" tab under /managePlugins:

<img width="1454" alt="image" src="https://user-images.githubusercontent.com/21689198/74189623-bfdec900-4c1e-11ea-91c5-997fce289089.png">

I've also included a handful of README edits.