### PR TITLE
Make ConverterResult store class of successful conversion

### DIFF
--- a/declarative-pipeline-migration-assistant-api/src/main/java/io/jenkins/plugins/todeclarative/converter/api/ConverterResult.java
+++ b/declarative-pipeline-migration-assistant-api/src/main/java/io/jenkins/plugins/todeclarative/converter/api/ConverterResult.java
@@ -18,7 +18,7 @@ public class ConverterResult
 
     private List<Supplier<ModelASTTreeStep>> wrappingTreeSteps = new ArrayList<>();
 
-    private List<String> convertedTypes = new ArrayList<>();
+    private List<Class> convertedTypes = new ArrayList<>();
 
     private List<Warning> warnings = new ArrayList<>();
 
@@ -57,12 +57,12 @@ public class ConverterResult
         return wrappingTreeSteps;
     }
 
-    public List<String> getConvertedTypes() {
+    public List<Class> getConvertedTypes() {
         return convertedTypes;
     }
 
-    public void addConvertedType(String typeClassName) {
-        convertedTypes.add(typeClassName);
+    public void addConvertedType(Class typeClass) {
+        convertedTypes.add(typeClass);
     }
 
     public List<Warning> getWarnings()

--- a/declarative-pipeline-migration-assistant/src/main/java/io/jenkins/plugins/todeclarative/converter/freestyle/FreestyleToDeclarativeConverter.java
+++ b/declarative-pipeline-migration-assistant/src/main/java/io/jenkins/plugins/todeclarative/converter/freestyle/FreestyleToDeclarativeConverter.java
@@ -120,7 +120,7 @@ public class FreestyleToDeclarativeConverter extends SingleTypedConverter<FreeSt
                     matched = true;
                     if ( converter.convert(request, result, type) )
                     {
-                        result.addConvertedType(type.getClass().getName());
+                        result.addConvertedType(type.getClass());
                     } else
                     {
                         // TODO: log addition information for failed conversion?


### PR DESCRIPTION
Refactor so that the `ConverterResult` stores the class of the type that was converted instead of just the class name. This mirrors how `Warning` stores the class instead of just the class name.