### PR TITLE
Cleaning up plugin deps

### DIFF
--- a/declarative-pipeline-migration-assistant/pom.xml
+++ b/declarative-pipeline-migration-assistant/pom.xml
@@ -137,12 +137,6 @@
       <version>1.3</version>
       <optional>true</optional>
     </dependency>
-    <dependency>
-      <groupId>org.jenkins-ci.plugins</groupId>
-      <artifactId>matrix-project</artifactId>
-      <version>1.7.1</version>
-      <optional>true</optional>
-    </dependency>
     <!-- Test scope plugins -->
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>

--- a/declarative-pipeline-migration-assistant/pom.xml
+++ b/declarative-pipeline-migration-assistant/pom.xml
@@ -131,11 +131,6 @@
     </dependency>
     <!-- Test scope plugins -->
     <dependency>
-      <groupId>org.jenkins-ci.plugins</groupId>
-      <artifactId>matrix-project</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-basic-steps</artifactId>
       <scope>test</scope>

--- a/declarative-pipeline-migration-assistant/pom.xml
+++ b/declarative-pipeline-migration-assistant/pom.xml
@@ -38,7 +38,6 @@
     <dependency>
       <groupId>org.jenkins-ci.ui</groupId>
       <artifactId>jquery-detached</artifactId>
-      <version>1.2.1</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
@@ -51,12 +50,10 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>credentials-binding</artifactId>
-      <version>1.19</version>
     </dependency>
     <dependency>
       <groupId>org.kohsuke</groupId>
       <artifactId>access-modifier-annotation</artifactId>
-      <version>1.16</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
@@ -81,24 +78,20 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>mailer</artifactId>
-      <version>1.32</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>variant</artifactId>
-      <version>1.3</version>
     </dependency>
     <!-- Optional plugins -->
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>git</artifactId>
-      <version>3.9.4</version>
       <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>ssh-credentials</artifactId>
-      <version>1.17.4</version>
       <optional>true</optional>
     </dependency>
     <dependency>
@@ -134,26 +127,27 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>junit</artifactId>
-      <version>1.3</version>
       <optional>true</optional>
     </dependency>
     <!-- Test scope plugins -->
     <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>matrix-project</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-basic-steps</artifactId>
-      <version>2.18</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-durable-task-step</artifactId>
-      <version>2.31</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>token-macro</artifactId>
-      <version>2.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -171,19 +165,16 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>branch-api</artifactId>
-      <version>2.0.7</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>plain-credentials</artifactId>
-      <version>1.4</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>pipeline-build-step</artifactId>
-      <version>2.9</version>
       <scope>test</scope>
     </dependency>
   </dependencies>


### PR DESCRIPTION
Originally noticed something amiss by the presence of a `matrix-project` dep, which made no sense since there is no converter for this project type. Then I figured out this was a workaround for `RequireUpperBoundDeps` issues. But you are already using the `bom` which is designed to make this easy!