### PR TITLE
Remove unused and unsecure jquery-detached

### DIFF
--- a/declarative-pipeline-migration-assistant/pom.xml
+++ b/declarative-pipeline-migration-assistant/pom.xml
@@ -36,10 +36,6 @@
       <artifactId>workflow-api</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.jenkins-ci.ui</groupId>
-      <artifactId>jquery-detached</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-cps</artifactId>
     </dependency>


### PR DESCRIPTION
This project has `jquery-detached` in its POM but it seems it's not being used. It's an insecure version of jQuery and it should probably be removed.