### PR TITLE
setting an agents labels after is it created will not apply instantly

### DIFF
--- a/declarative-pipeline-migration-assistant/src/test/java/io/jenkins/plugins/todeclarative/converter/FreestyleTest.java
+++ b/declarative-pipeline-migration-assistant/src/test/java/io/jenkins/plugins/todeclarative/converter/FreestyleTest.java
@@ -96,8 +96,7 @@ public class FreestyleTest
         throws Exception
     {
         String nodeName = "FOO_AGENT";
-        Slave slave = j.createOnlineSlave();
-        slave.setLabelString( nodeName );
+        Slave slave = j.createSlave(nodeName, null);
 
         String projectName = Long.toString( System.currentTimeMillis() );
         FreeStyleProject p = j.createFreeStyleProject( projectName );
@@ -450,8 +449,7 @@ public class FreestyleTest
         throws Exception
     {
 
-        Slave slave = j.createOnlineSlave();
-        slave.setLabelString( "FOO_AGENT" );
+        Slave slave = j.createSlave("FOO_AGENT", null);
 
         String projectName = Long.toString( System.currentTimeMillis() );
         FreeStyleProject p = j.createFreeStyleProject( projectName );
@@ -494,8 +492,7 @@ public class FreestyleTest
         throws Exception
     {
         Assume.assumeFalse(Functions.isWindows());
-        Slave slave = j.createOnlineSlave();
-        slave.setLabelString( "FOO_AGENT" );
+        Slave slave = j.createSlave("FOO_AGENT", null);
 
         String projectName = Long.toString( System.currentTimeMillis() );
         FreeStyleProject p = j.createFreeStyleProject( projectName );
@@ -571,8 +568,7 @@ public class FreestyleTest
     public void get_warning()
         throws Exception
     {
-        Slave slave = j.createOnlineSlave();
-        slave.setLabelString( "FOO_AGENT" );
+        Slave slave = j.createSlave("FOO_AGENT", null);
 
         String projectName = Long.toString( System.currentTimeMillis() );
         FreeStyleProject p = j.createFreeStyleProject( projectName );

--- a/declarative-pipeline-migration-assistant/src/test/java/io/jenkins/plugins/todeclarative/converter/ToDeclarativeActionTest.java
+++ b/declarative-pipeline-migration-assistant/src/test/java/io/jenkins/plugins/todeclarative/converter/ToDeclarativeActionTest.java
@@ -59,8 +59,7 @@ public class ToDeclarativeActionTest
     @Test
     public void simpleActionRun() throws Exception
     {
-        Slave slave = j.createOnlineSlave();
-        slave.setLabelString( "FOO_AGENT" );
+        Slave slave = j.createSlave("FOO_AGENT", null);
 
         String projectName = Long.toString( System.currentTimeMillis() );
         FreeStyleProject p = j.createFreeStyleProject( projectName );

--- a/declarative-pipeline-migration-assistant/src/test/java/io/jenkins/plugins/todeclarative/converter/listener/ToDeclarativeConverterListenerTest.java
+++ b/declarative-pipeline-migration-assistant/src/test/java/io/jenkins/plugins/todeclarative/converter/listener/ToDeclarativeConverterListenerTest.java
@@ -29,8 +29,7 @@ public class ToDeclarativeConverterListenerTest {
 
     @Test public void onConversion() throws Exception {
         String nodeName = "FOO_AGENT";
-        Slave slave = r.createOnlineSlave();
-        slave.setLabelString( nodeName );
+        Slave slave = r.createSlave(nodeName, null);
         String projectName = Long.toString( System.currentTimeMillis() );
         FreeStyleProject p = r.createFreeStyleProject( projectName );
         p.setAssignedLabel( Label.get( nodeName ) );


### PR DESCRIPTION
This causes some flakes as the labels will not be re-evaluated until a
periodic `trimLabels` in the future or a slave being added removed that
has the same labels as the agent that had setLabels called on it.

Additionally we do not need to wait for the agent to come online as the
jobs will wait anyway - this allows us to speed up the tests as we can
continue to do some work whilst the agent is connecting.

<!-- Please describe your pull request here. -->

- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
