### PR TITLE
Switch from deprecated `useAci` syntax to `useContainerAgent`

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,5 @@
 // NOTE: Cannot use ACI agents because build requires `unzip` to be available
-buildPlugin(useAci: false, configurations: [
+buildPlugin(useContainerAgent: true, configurations: [
         [ platform: "linux", jdk: "8" ],
         [ platform: "windows", jdk: "8" ],
         [ platform: "linux", jdk: "11" ]


### PR DESCRIPTION
This is an automatic pull request, that switches from the deprecated `useAci` syntax to `useContainerAgent`.

Switching to the new syntax is a drop-in replacement and requires no further work from your side.
Once you merge this PR, you address the warning currently emitted on all builds in this repository:
![](https://i.imgur.com/8uCZKKC.png)

In case of questions, please ping me, `@NotMyFault`.

Additional information:

- [Click here to read more about the deprecated syntax](https://github.com/jenkins-infra/pipeline-library/#optional-arguments)

cc @olamy 