### PR TITLE
Add support of build-blocker-plugin (but need 1.7.9 release)

### DIFF
--- a/declarative-pipeline-migration-assistant/pom.xml
+++ b/declarative-pipeline-migration-assistant/pom.xml
@@ -38,12 +38,11 @@
     </dependency>
     <!--
     remove when merge of https://github.com/jenkinsci/build-blocker-plugin/pull/19
-    remove snapshot repository as well
     -->
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>build-blocker-plugin</artifactId>
-      <version>1.7.9-20230810.030611-1</version>
+      <version>1.7.8</version>
       <optional>true</optional>
     </dependency>
     <dependency>

--- a/declarative-pipeline-migration-assistant/pom.xml
+++ b/declarative-pipeline-migration-assistant/pom.xml
@@ -38,7 +38,7 @@
     </dependency>
     <!--
     remove when merge of https://github.com/jenkinsci/build-blocker-plugin/pull/19
-    remove snapshot repository as well  
+    remove snapshot repository as well
     -->
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>

--- a/declarative-pipeline-migration-assistant/pom.xml
+++ b/declarative-pipeline-migration-assistant/pom.xml
@@ -36,6 +36,16 @@
       <version>1.0.2</version>
       <optional>true</optional>
     </dependency>
+    <!--
+    remove when merge of https://github.com/jenkinsci/build-blocker-plugin/pull/19
+    remove snapshot repository as well  
+    -->
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>build-blocker-plugin</artifactId>
+      <version>1.7.9-20230810.030611-1</version>
+      <optional>true</optional>
+    </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>build-timeout</artifactId>
@@ -168,6 +178,19 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+
+  <repositories>
+    <repository>
+      <releases>
+        <enabled>false</enabled>
+      </releases>
+      <snapshots>
+        <enabled>true</enabled>
+      </snapshots>
+      <id>jenkins.snapshots</id>
+      <url>https://repo.jenkins-ci.org/snapshots/</url>
+    </repository>
+  </repositories>
   <build>
     <resources>
       <resource>

--- a/declarative-pipeline-migration-assistant/src/main/java/io/jenkins/plugins/todeclarative/converter/jobproperty/BuildBlockerPropertyConverter.java
+++ b/declarative-pipeline-migration-assistant/src/main/java/io/jenkins/plugins/todeclarative/converter/jobproperty/BuildBlockerPropertyConverter.java
@@ -1,0 +1,46 @@
+package io.jenkins.plugins.todeclarative.converter.jobproperty;
+
+import static io.jenkins.plugins.todeclarative.converter.api.ModelASTUtils.buildKeyPairArg;
+
+import hudson.plugins.buildblocker.BuildBlockerProperty;
+import io.jenkins.plugins.todeclarative.converter.api.ConverterRequest;
+import io.jenkins.plugins.todeclarative.converter.api.ConverterResult;
+import io.jenkins.plugins.todeclarative.converter.api.ModelASTUtils;
+import io.jenkins.plugins.todeclarative.converter.api.SingleTypedConverter;
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.commons.lang3.StringUtils;
+import org.jenkinsci.plugins.pipeline.modeldefinition.ast.ModelASTMethodArg;
+import org.jenkinsci.plugins.pipeline.modeldefinition.ast.ModelASTOption;
+import org.jenkinsci.plugins.variant.OptionalExtension;
+
+@OptionalExtension(requirePlugins = {"build-blocker-plugin"})
+public class BuildBlockerPropertyConverter extends SingleTypedConverter<BuildBlockerProperty> {
+    @Override
+    public boolean convert(ConverterRequest request, ConverterResult result, Object target) {
+        BuildBlockerProperty buildBlockerProperty = (BuildBlockerProperty) target;
+
+        ModelASTOption buildBlockerOption = new ModelASTOption(this);
+        buildBlockerOption.setName("buildBlocker");
+        //  buildBlocker (useBuildBlocker: true, blockLevel: 'NODE', scanQueueFor: 'ALL', blockingJobs: 'foo-.*')
+
+        List<ModelASTMethodArg> optionArgs = new ArrayList<>();
+        optionArgs.add(buildKeyPairArg("useBuildBlocker", buildBlockerProperty.isUseBuildBlocker()));
+
+        if (buildBlockerProperty.getBlockLevel() != null) {
+            optionArgs.add(buildKeyPairArg(
+                    "blockLevel", buildBlockerProperty.getBlockLevel().toString()));
+        }
+        if (buildBlockerProperty.getScanQueueFor() != null) {
+            optionArgs.add(buildKeyPairArg(
+                    "scanQueueFor", buildBlockerProperty.getScanQueueFor().toString()));
+        }
+        if (StringUtils.isNotBlank(buildBlockerProperty.getBlockingJobs())) {
+            optionArgs.add(buildKeyPairArg("blockingJobs", buildBlockerProperty.getBlockingJobs()));
+        }
+        buildBlockerOption.setArgs(optionArgs);
+
+        ModelASTUtils.addOption(result.getModelASTPipelineDef(), buildBlockerOption);
+        return true;
+    }
+}

--- a/declarative-pipeline-migration-assistant/src/test/java/io/jenkins/plugins/todeclarative/converter/jobproperty/BuildBlockerPropertyConverterTest.java
+++ b/declarative-pipeline-migration-assistant/src/test/java/io/jenkins/plugins/todeclarative/converter/jobproperty/BuildBlockerPropertyConverterTest.java
@@ -1,0 +1,41 @@
+package io.jenkins.plugins.todeclarative.converter.jobproperty;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
+import hudson.ExtensionList;
+import hudson.plugins.buildblocker.BuildBlockerProperty;
+import io.jenkins.plugins.todeclarative.converter.api.ConverterRequest;
+import io.jenkins.plugins.todeclarative.converter.api.ConverterResult;
+import org.jenkinsci.plugins.pipeline.modeldefinition.ast.ModelASTOption;
+import org.jenkinsci.plugins.pipeline.modeldefinition.ast.ModelASTOptions;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+
+public class BuildBlockerPropertyConverterTest {
+    @Rule
+    public JenkinsRule j = new JenkinsRule();
+
+    @Test
+    public void simpletest() throws Exception {
+
+        BuildBlockerProperty buildBlockerProperty = new BuildBlockerProperty(true, "NODE", "ALL", "foo");
+        BuildBlockerPropertyConverter converter = ExtensionList.lookupSingleton(BuildBlockerPropertyConverter.class);
+
+        assertTrue(converter.canConvert(buildBlockerProperty));
+        ConverterResult result = new ConverterResult();
+        converter.convert(new ConverterRequest(), result, buildBlockerProperty);
+        ModelASTOptions options = result.getModelASTPipelineDef().getOptions();
+        assertEquals(1, options.getOptions().size());
+        ModelASTOption option = options.getOptions().get(0);
+        assertEquals("buildBlocker", option.getName());
+        String groovy = option.toGroovy();
+        assertThat(groovy, containsString("useBuildBlocker: true"));
+        assertThat(groovy, containsString("blockLevel: 'NODE'"));
+        assertThat(groovy, containsString("scanQueueFor: 'ALL'"));
+        assertThat(groovy, containsString("blockingJobs: 'foo'"));
+    }
+}


### PR DESCRIPTION
depends on merge and release of https://github.com/jenkinsci/build-blocker-plugin/pull/19

Signed-off-by: Olivier Lamy <olamy@apache.org>
