### PR TITLE
Prototype JS Removal changes

### DIFF
--- a/declarative-pipeline-migration-assistant/src/main/webapp/js/prism-live.js
+++ b/declarative-pipeline-migration-assistant/src/main/webapp/js/prism-live.js
@@ -130,7 +130,7 @@ var _ = Prism.Live = class PrismLive {
 						var snippetExpanded = this.expandSnippet(selector);
 
 						if (snippetExpanded) {
-							requestAnimationFrame(() => $.fire(this.textarea, "input"));
+							requestAnimationFrame(() => Event.fire(this.textarea, "input"));
 						}
 						else {
 							this.insert(this.indent);
@@ -744,7 +744,7 @@ $.ready().then(() => {
 	_.supportsExecCommand = !!t.value;
 	t.remove();
 
-	$$(":not(.prism-live) > textarea.prism-live").forEach(textarea => {
+	document.querySelectorAll(":not(.prism-live) > textarea.prism-live").forEach(textarea => {
 		if (!_.all.get(textarea)) {
 			new _(textarea);
 		}

--- a/declarative-pipeline-migration-assistant/src/main/webapp/js/prism-live.js
+++ b/declarative-pipeline-migration-assistant/src/main/webapp/js/prism-live.js
@@ -130,7 +130,7 @@ var _ = Prism.Live = class PrismLive {
 						var snippetExpanded = this.expandSnippet(selector);
 
 						if (snippetExpanded) {
-							requestAnimationFrame(() => Event.fire(this.textarea, "input"));
+							requestAnimationFrame(() => this.textarea.dispatchEvent(new Event("input")));
 						}
 						else {
 							this.insert(this.indent);

--- a/declarative-pipeline-migration-assistant/src/main/webapp/js/prism.js
+++ b/declarative-pipeline-migration-assistant/src/main/webapp/js/prism.js
@@ -1101,7 +1101,7 @@ Prism.hooks.add('wrap', function(env) {
 		var hash = location.hash.slice(1);
 
 		// Remove pre-existing temporary lines
-		$$('.temporary.line-highlight').forEach(function (line) {
+		document.querySelector('.temporary.line-highlight').forEach(function (line) {
 			line.parentNode.removeChild(line);
 		});
 
@@ -1146,7 +1146,7 @@ Prism.hooks.add('wrap', function(env) {
 		 * tags change the content of the <code> tag.
 		 */
 		var num = 0;
-		$$('.line-highlight', pre).forEach(function (line) {
+		document.querySelectorAll('.line-highlight', pre).forEach(function (line) {
 			num += line.textContent.length;
 			line.parentNode.removeChild(line);
 		});
@@ -1181,7 +1181,7 @@ Prism.hooks.add('wrap', function(env) {
 	window.addEventListener('hashchange', applyHash);
 	window.addEventListener('resize', function () {
 		var actions = [];
-		$$('pre[data-line]').forEach(function (pre) {
+		document.querySelectorAll('pre[data-line]').forEach(function (pre) {
 			actions.push(highlightLines(pre));
 		});
 		actions.forEach(callFunction);

--- a/declarative-pipeline-migration-assistant/src/main/webapp/js/prism.js
+++ b/declarative-pipeline-migration-assistant/src/main/webapp/js/prism.js
@@ -1101,7 +1101,7 @@ Prism.hooks.add('wrap', function(env) {
 		var hash = location.hash.slice(1);
 
 		// Remove pre-existing temporary lines
-		document.querySelector('.temporary.line-highlight').forEach(function (line) {
+		document.querySelectorAll('.temporary.line-highlight').forEach(function (line) {
 			line.parentNode.removeChild(line);
 		});
 


### PR DESCRIPTION
Purpose of the plugin is to Migrate from Freestyle project to declarative pipeline project. Installed the declarative Pipeline plugin during local testing before code change with the pipeline script: 

![declarative_before_changes](https://github.com/jenkinsci/declarative-pipeline-migration-assistant-plugin/assets/142486073/9331f342-7096-42ee-8dd3-ca1fd092fc5d)


Prototype JS Removal affected code changes:

1. declarative-pipeline-migration-assistant/src/main/webapp/js/prism-live.js 
Line 133
Changed from **$.fire** to **this.textarea.dispatchEvent(new Event("input"));** 
--> Here is the replacement function eg: dispatchEvent(new Event("event")); for fire() function.
 When clicked the 'tab' without selecting any content in the textarea,  the keydown event will get triggered and else condition will get called which has this prototype change as below.

![image](https://github.com/jenkinsci/declarative-pipeline-migration-assistant-plugin/assets/142486073/a5a152e4-dc92-4e5b-9834-9eca995c8fc8)


2. declarative-pipeline-migration-assistant/src/main/webapp/js/prism-live.js
Line 747
Changed from **$$(":not(.prism-live)** to **document.querySelectorAll(":not(.prism-live)**
--> Here is the double dollar $$ in the element being replaced by document.querySelectorAll which is performing the iteration and to create a new textarea.
 When we navigate from todeclarative plugin,  During onload of the plugin, the $$(":not(.prism-live) function will get called and with the changes and we were able to confirm without any issues.


![image](https://github.com/jenkinsci/declarative-pipeline-migration-assistant-plugin/assets/142486073/6ea88281-670f-49f4-9a83-5fbe076bfb01)


3. declarative-pipeline-migration-assistant/src/main/webapp/js/prism.js
   Line 1104
  Changed from **$$('.temporary.line-highlight')** to **document.querySelectorAll('.temporary.line-highlight')**

During onload of the todeclarative plugin, the applyHash() function will get called which has the changes. This line will help to remove the temporary high lighted lines in the plugin. We found there is no issues after the replacement code changes.

![image](https://github.com/jenkinsci/declarative-pipeline-migration-assistant-plugin/assets/142486073/3a755d05-4a55-477f-8462-9f610a9967d5)


   Line 1149
  Changed from **$$('.line-highlight', pre)** to **document.querySelectorAll('.line-highlight', pre)**

During onload of the plugin, When a lines are highlighted which is under the pre tags, then this below condition will get called. I 
 added the pre tag and code tag for some of the lines to get highlighted in the declarative plugin. After our code changes, when the lines are executed. it looks fine.
  
![image](https://github.com/jenkinsci/declarative-pipeline-migration-assistant-plugin/assets/142486073/50a4860d-9a0d-4452-b549-c810c79f177c)


   Line 1184
  Changed from **$$('pre[data-line]')** to **document.querySelectorAll('pre[data-line]')**

After the plugin got loaded. I tried to resize the window by increase the screen size. The below window resize function got triggered. After our code changes. The changed code executed without any issues as below.
  
![image](https://github.com/jenkinsci/declarative-pipeline-migration-assistant-plugin/assets/142486073/90fd6cf3-5297-43b0-b631-a672d594dc1a)


**Notable False positives**

1. ./declarative-pipeline-migration-assistant-plugin/declarative-pipeline-migration-assistant/src/main/webapp/js/bliss.shy.min.js
Line 270, 413, 470
Code: $(arguments) - 
--> Bliss.shy.min.js is the external javascript library which help us to achieve the plain native javascript with bliss.shy.js which is using the **$(argument)** and its not affected the prototype js removal. 
External Javascript Library link for Ref:
 https://blissfuljs.com/#download
https://blissfuljs.com/docs

2. ./declarative-pipeline-migration-assistant-plugin/declarative-pipeline-migration-assistant/src/main/webapp/js/clipboard.min.js
Line: 287
Code:  this.on(t, o, n)
--> clipboard.js is the external javascript library used to copy the content in the web which is using **this.on()** and its not related to the prototype js removal.
External Javascript Library link for Ref:
https://clipboardjs.com/

   
Testing made as below After the code changes. enabled the prototype JS flag. Able to test the declarative pipeline. No discripancy occurred. 


1. Created a Freestyle project called myJenkins in my local. And installed the Declarative pipeline plugin
 

2. Navigate to the myJenkins project and click the **To declarative plugin**


5. After creating the pipeline script. During onload of the declarative pipeline plugin was able to load all the pertinent javascript files and we can verify our code changes that has no conflicts occurred.

![image](https://github.com/jenkinsci/declarative-pipeline-migration-assistant-plugin/assets/142486073/cdc50b44-7e0d-46cb-b7ab-22c740230c45)




