### PR TITLE
Require Jenkins 2.401.3 or newer

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,5 @@
 // NOTE: Cannot use ACI agents because build requires `unzip` to be available
 buildPlugin(useContainerAgent: true, configurations: [
-        [ platform: "linux", jdk: "17" ],
-        [ platform: "windows", jdk: "11" ]
+        [ platform: "linux", jdk: "21" ],
+        [ platform: "windows", jdk: "17" ]
 ])

--- a/declarative-pipeline-migration-assistant/pom.xml
+++ b/declarative-pipeline-migration-assistant/pom.xml
@@ -46,7 +46,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>build-timeout</artifactId>
-      <version>1.25</version>
+      <version>1.31</version>
       <optional>true</optional>
     </dependency>
     <dependency>

--- a/declarative-pipeline-migration-assistant/pom.xml
+++ b/declarative-pipeline-migration-assistant/pom.xml
@@ -18,7 +18,6 @@
     <dependency>
       <groupId>com.coravy.hudson.plugins.github</groupId>
       <artifactId>github</artifactId>
-      <version>1.37.2</version>
       <optional>true</optional>
     </dependency>
     <dependency>
@@ -33,7 +32,6 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>ansicolor</artifactId>
-      <version>1.0.2</version>
       <optional>true</optional>
     </dependency>
     <!--

--- a/declarative-pipeline-migration-assistant/pom.xml
+++ b/declarative-pipeline-migration-assistant/pom.xml
@@ -140,7 +140,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>jira</artifactId>
-      <version>3.9</version>
+      <version>3.12</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>4.75</version>
+    <version>4.76</version>
     <relativePath />
   </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
     <jacoco.coverage.target>0.70</jacoco.coverage.target>
     <!-- For non-ci builds we'd like the build to still complete if jacoco metrics aren't met. -->
     <jacoco.haltOnFailure>false</jacoco.haltOnFailure>
-    <jenkins.version>2.361.4</jenkins.version>
+    <jenkins.version>2.401.3</jenkins.version>
     <revision>1.6.2</revision>
     <spotless.check.skip>false</spotless.check.skip>
   </properties>
@@ -74,8 +74,8 @@
     <dependencies>
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
-        <artifactId>bom-2.361.x</artifactId>
-        <version>2102.v854b_fec19c92</version>
+        <artifactId>bom-2.401.x</artifactId>
+        <version>2661.vb_b_60650f6d97</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
## Require Jenkins 2.401.3 or newer

The [plugin installation statistics](https://stats.jenkins.io/pluginversions/declarative-pipeline-migration-assistant.html) show:

* 88% of the installations of the most recent release are already running Jenkins 2.401.3 or newer.  The most recent release was 4 months ago.  The most recent release is installed on 460 / 1388 total installations.
* 48% of the installations of the next most recent release are already running Jenkins 2.401.3 or newer.  That release was 6 months ago.  That release is installed on 104 / 1388 total installations.

Those installation results show that requiring Jenkins 2.401.3 or newer will have very little impact on most plugin users.  Those who are willing to upgrade are already using Jenkins 2.401.3 or newer.  Those who are not upgrading will not upgrade to the newer version either.

Users should upgrade to a newer Jenkins core release to assure they have all the most recent security fixes.

### Rely on more of the plugin BOM

Updating to require Jenkins 2.401.3 or newer allows us to rely on the plugin bill of materials for two more version declarations:

* GitHub plugin
* Ansicolor plugin

Updating to require Jenkins 2.401.3 replaces the following two pull requests:

* #233
* #234

### Reduce risk of issues in plugin BOM

In addition, this pull request avoids an outdated jar dependency from the version of the JIRA plugin that was previously tested.  It replaces pull request:

* #235

It would be much appreciated to have a release of the plugin so that the outdated jar dependency is removed.  We don't want to risk disrupting the plugin bill of materials if we can avoid it.

First detected in https://github.com/jenkins-infra/helpdesk/issues/3872

### Test with build timeout plugin that removes Prototype.js

In addition, this pull request updates the build time plugin test dependency to use the build timeout plugin release that removes Prototype.js.  It replaces pull request:

* #203

### Testing done

Confirmed tests pass with Java 11 on Linux.  Updated Jenkinsfile to test with Java 21 and Java 17 so that it is verified with Java 21 on Linux and Java 17 on Windows.  The plugin continues to be tested with Java 11 in the plugin bill of materials.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
