### PR TITLE
Adapt JUnitResultArchiverConverterTest to upstream JUnit plugin changes

### DIFF
--- a/declarative-pipeline-migration-assistant/pom.xml
+++ b/declarative-pipeline-migration-assistant/pom.xml
@@ -76,9 +76,6 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>junit</artifactId>
-      <!-- TODO: Remove explicit version once BOM is bumped to a version that
-           pulls this in automatically -->
-      <version>1259.v65ffcef24a_88</version>
       <optional>true</optional>
     </dependency>
     <dependency>

--- a/declarative-pipeline-migration-assistant/pom.xml
+++ b/declarative-pipeline-migration-assistant/pom.xml
@@ -76,6 +76,9 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>junit</artifactId>
+      <!-- TODO: Remove explicit version once BOM is bumped to a version that
+           pulls this in automatically -->
+      <version>1259.v65ffcef24a_88</version>
       <optional>true</optional>
     </dependency>
     <dependency>

--- a/declarative-pipeline-migration-assistant/src/test/java/io/jenkins/plugins/todeclarative/converter/publisher/JUnitResultArchiverConverterTest.java
+++ b/declarative-pipeline-migration-assistant/src/test/java/io/jenkins/plugins/todeclarative/converter/publisher/JUnitResultArchiverConverterTest.java
@@ -23,7 +23,7 @@ public class JUnitResultArchiverConverterTest {
 
         JUnitResultArchiver publisher = new JUnitResultArchiver("**/**.xml");
         publisher.setHealthScaleFactor(2);
-        publisher.setKeepLongStdio(true);
+        publisher.setStdioRetention("ALL");
         p.getPublishersList().add(publisher);
 
         JUnitResultArchiverConverter converter =
@@ -38,7 +38,7 @@ public class JUnitResultArchiverConverterTest {
         // step($class: 'JUnitResultArchiver', healthScaleFactor: 2.0, keepLongStdio: true, testResults: '**/**.xml')
         assertThat(groovy, containsString("$class: 'JUnitResultArchiver'"));
         assertThat(groovy, containsString("healthScaleFactor: 2.0"));
-        assertThat(groovy, containsString("keepLongStdio: true"));
+        assertThat(groovy, containsString("stdioRetention: 'ALL'"));
         assertThat(groovy, containsString("testResults: '**/**.xml'"));
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -79,14 +79,6 @@
         <type>pom</type>
         <scope>import</scope>
       </dependency>
-
-      <!-- TODO: Remove explicit version once BOM is bumped to a version that
-           pulls this in automatically -->
-      <dependency>
-        <groupId>io.jenkins-ci.plugins</groupId>
-        <artifactId>junit</artifactId>
-        <version>1259.v65ffcef24a_88</version>
-      </dependency>
     </dependencies>
   </dependencyManagement>
 

--- a/pom.xml
+++ b/pom.xml
@@ -79,6 +79,14 @@
         <type>pom</type>
         <scope>import</scope>
       </dependency>
+
+      <!-- TODO: Remove explicit version once BOM is bumped to a version that
+           pulls this in automatically -->
+      <dependency>
+        <groupId>io.jenkins-ci.plugins</groupId>
+        <artifactId>junit</artifactId>
+        <version>1259.v65ffcef24a_88</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

This ports [upstream changes](https://github.com/jenkinsci/junit-plugin/pull/601) from the JUnit plugin that replaced the keepLongStdio property with stdioRetention in https://github.com/jenkinsci/junit-plugin/pull/601. Without this change, the affected test case fails when used with newer versions of the JUnit plugin.

### Testing done

I tweaked the POM to use the [latest release](https://github.com/jenkinsci/junit-plugin/releases/tag/1259.v65ffcef24a_88) of the JUnit plugin, then ran existing unit tests, one of which failed. After making this change, the test (and all others) passed.

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```
