### PR TITLE
[BEE-69470] Migrate commons-lang2 to jdk apis

### DIFF
--- a/declarative-pipeline-migration-assistant/src/main/java/io/jenkins/plugins/todeclarative/converter/builder/MavenConverter.java
+++ b/declarative-pipeline-migration-assistant/src/main/java/io/jenkins/plugins/todeclarative/converter/builder/MavenConverter.java
@@ -16,7 +16,6 @@ import jenkins.mvn.FilePathGlobalSettingsProvider;
 import jenkins.mvn.FilePathSettingsProvider;
 import jenkins.mvn.GlobalSettingsProvider;
 import jenkins.mvn.SettingsProvider;
-import org.apache.commons.lang.StringUtils;
 import org.jenkinsci.plugins.pipeline.modeldefinition.ast.ModelASTBranch;
 import org.jenkinsci.plugins.pipeline.modeldefinition.ast.ModelASTEnvironment;
 import org.jenkinsci.plugins.pipeline.modeldefinition.ast.ModelASTEnvironmentValue;
@@ -50,7 +49,7 @@ public class MavenConverter extends SingleTypedConverter<Maven> {
         JDK jdk = freeStyleProject.getJDK();
         // default jdk may have configured automatically but we don't want that
         if (jdk != null
-                && !(Jenkins.get().getJDKs().size() == 1 && StringUtils.equalsIgnoreCase("default", jdk.getName()))) {
+                && !(Jenkins.get().getJDKs().size() == 1 && "default".equalsIgnoreCase(jdk.getName()))) {
             ModelASTKey key = new ModelASTKey(this);
             key.setKey("jdk");
             ModelASTUtils.addTool(
@@ -68,16 +67,19 @@ public class MavenConverter extends SingleTypedConverter<Maven> {
 
         ArgumentListBuilder args = new ArgumentListBuilder();
         args.add("mvn");
-        Arrays.asList(StringUtils.split(maven.getTargets())).stream().forEach(s -> args.add(s));
+        String targets = maven.getTargets();
+        if (targets != null && !targets.isBlank()) {
+            Arrays.stream(targets.trim().split("\\s+")).forEach(args::add);
+        }
         if (maven.usePrivateRepository) {
             args.add("-Dmaven.repo.local=.repository");
         }
 
-        if (StringUtils.isNotBlank(maven.pom)) {
+        if (maven.pom != null && !maven.pom.isBlank()) {
             args.add("-f", maven.pom);
         }
 
-        if (StringUtils.isNotBlank(maven.properties)) {
+        if (maven.properties != null && !maven.properties.isBlank()) {
             args.add(maven.properties);
         }
 
@@ -85,7 +87,7 @@ public class MavenConverter extends SingleTypedConverter<Maven> {
             SettingsProvider settingsProvider = maven.getSettings();
             if (settingsProvider instanceof FilePathSettingsProvider) {
                 String settingsPath = ((FilePathSettingsProvider) settingsProvider).getPath();
-                if (StringUtils.isNotBlank(settingsPath)) {
+                if (settingsPath != null && !settingsPath.isBlank()) {
                     args.add("-s", settingsPath);
                 }
             }
@@ -95,7 +97,7 @@ public class MavenConverter extends SingleTypedConverter<Maven> {
             GlobalSettingsProvider globalSettingsProvider = maven.getGlobalSettings();
             if (globalSettingsProvider instanceof FilePathGlobalSettingsProvider) {
                 String settingsPath = ((FilePathGlobalSettingsProvider) globalSettingsProvider).getPath();
-                if (StringUtils.isNotBlank(settingsPath)) {
+                if (settingsPath != null && !settingsPath.isBlank()) {
                     args.add("-gs", settingsPath);
                 }
             }
@@ -107,7 +109,7 @@ public class MavenConverter extends SingleTypedConverter<Maven> {
         step.setArgs(singleArgument);
         step.setName("sh");
 
-        if (StringUtils.isNotBlank(maven.jvmOptions)) {
+        if (maven.jvmOptions != null && !maven.jvmOptions.isBlank()) {
             ModelASTEnvironment environment = stage.getEnvironment();
             if (environment == null) {
                 environment = new ModelASTEnvironment(this);

--- a/declarative-pipeline-migration-assistant/src/main/java/io/jenkins/plugins/todeclarative/converter/builder/MavenConverter.java
+++ b/declarative-pipeline-migration-assistant/src/main/java/io/jenkins/plugins/todeclarative/converter/builder/MavenConverter.java
@@ -48,8 +48,7 @@ public class MavenConverter extends SingleTypedConverter<Maven> {
         FreeStyleProject freeStyleProject = (FreeStyleProject) request.getJob();
         JDK jdk = freeStyleProject.getJDK();
         // default jdk may have configured automatically but we don't want that
-        if (jdk != null
-                && !(Jenkins.get().getJDKs().size() == 1 && "default".equalsIgnoreCase(jdk.getName()))) {
+        if (jdk != null && !(Jenkins.get().getJDKs().size() == 1 && "default".equalsIgnoreCase(jdk.getName()))) {
             ModelASTKey key = new ModelASTKey(this);
             key.setKey("jdk");
             ModelASTUtils.addTool(

--- a/declarative-pipeline-migration-assistant/src/main/java/io/jenkins/plugins/todeclarative/converter/buildwrapper/AnsiColorWrapperConverter.java
+++ b/declarative-pipeline-migration-assistant/src/main/java/io/jenkins/plugins/todeclarative/converter/buildwrapper/AnsiColorWrapperConverter.java
@@ -7,7 +7,6 @@ import io.jenkins.plugins.todeclarative.converter.api.ModelASTUtils;
 import io.jenkins.plugins.todeclarative.converter.api.SingleTypedConverter;
 import java.util.ArrayList;
 import java.util.List;
-import org.apache.commons.lang.StringUtils;
 import org.jenkinsci.plugins.pipeline.modeldefinition.ast.ModelASTMethodArg;
 import org.jenkinsci.plugins.pipeline.modeldefinition.ast.ModelASTOption;
 import org.jenkinsci.plugins.pipeline.modeldefinition.ast.ModelASTOptions;
@@ -26,7 +25,7 @@ public class AnsiColorWrapperConverter extends SingleTypedConverter<AnsiColorBui
         AnsiColorBuildWrapper wrapper = (AnsiColorBuildWrapper) target;
         String colorMapName = wrapper.getColorMapName();
 
-        if (StringUtils.isEmpty(colorMapName)) {
+        if (colorMapName.isEmpty()) {
             return false;
         }
 

--- a/declarative-pipeline-migration-assistant/src/main/java/io/jenkins/plugins/todeclarative/converter/freestyle/FreestyleToDeclarativeConverter.java
+++ b/declarative-pipeline-migration-assistant/src/main/java/io/jenkins/plugins/todeclarative/converter/freestyle/FreestyleToDeclarativeConverter.java
@@ -14,7 +14,6 @@ import io.jenkins.plugins.todeclarative.converter.api.SingleTypedConverter;
 import io.jenkins.plugins.todeclarative.converter.api.Warning;
 import java.util.Arrays;
 import java.util.Map;
-import org.apache.commons.lang.StringUtils;
 import org.jenkinsci.plugins.pipeline.modeldefinition.ast.ModelASTAgent;
 import org.jenkinsci.plugins.pipeline.modeldefinition.ast.ModelASTKey;
 
@@ -45,7 +44,7 @@ public class FreestyleToDeclarativeConverter extends SingleTypedConverter<FreeSt
 
             String customWorkspace = freeStyleProject.getCustomWorkspace();
 
-            if (StringUtils.isBlank(label) && StringUtils.isBlank(customWorkspace)) {
+            if ((label == null || label.isBlank()) && (customWorkspace == null || customWorkspace.isBlank())) {
                 ModelASTKey agentKey = new ModelASTKey(this);
                 agentKey.setKey("any");
                 agent.setAgentType(agentKey);
@@ -55,12 +54,12 @@ public class FreestyleToDeclarativeConverter extends SingleTypedConverter<FreeSt
                     @Override
                     public String toGroovy() {
                         StringBuilder groovy = new StringBuilder("{\n node { \n");
-                        if (StringUtils.isNotBlank(label)) {
+                        if (label != null && !label.isBlank()) {
                             groovy.append("    label '" + label + "'\n");
                         } else {
                             groovy.append("    label ''\n");
                         }
-                        if (StringUtils.isNotBlank(customWorkspace)) {
+                        if (customWorkspace != null && !customWorkspace.isBlank()) {
                             groovy.append("    customWorkspace \"" + customWorkspace + "\"\n");
                         }
                         groovy.append("    } \n}");

--- a/declarative-pipeline-migration-assistant/src/test/java/io/jenkins/plugins/todeclarative/converter/FreestyleTest.java
+++ b/declarative-pipeline-migration-assistant/src/test/java/io/jenkins/plugins/todeclarative/converter/FreestyleTest.java
@@ -56,13 +56,13 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 import jenkins.model.BuildDiscarder;
 import jenkins.model.BuildDiscarderProperty;
 import jenkins.model.Jenkins;
 import jenkins.triggers.ReverseBuildTrigger;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
-import org.apache.commons.lang.StringUtils;
 import org.hamcrest.CoreMatchers;
 import org.jenkins.plugins.lockableresources.RequiredResourcesProperty;
 import org.jenkinsci.lib.configprovider.ConfigProvider;
@@ -304,7 +304,7 @@ public class FreestyleTest {
         }
         Files.createDirectories(f.toPath());
         String workspace =
-                Functions.isWindows() ? StringUtils.replace(f.getAbsolutePath(), "\\", "\\\\") : f.getAbsolutePath();
+                Functions.isWindows() ? f.getAbsolutePath().replace("\\", "\\\\") : f.getAbsolutePath();
         p.setCustomWorkspace(workspace);
 
         p.addProperty(new BuildDiscarderProperty(new NoOpBuildDiscarder()));
@@ -613,20 +613,20 @@ public class FreestyleTest {
         assertEquals(
                 1,
                 converterResult.getWarnings().stream() //
-                        .filter(warning -> StringUtils.equals(warning.getTypeName(), FakeBuilder.class.getName())) //
+                        .filter(warning -> Objects.equals(warning.getTypeName(),FakeBuilder.class.getName())) //
                         .count());
 
         assertEquals(
                 1,
                 converterResult.getWarnings().stream() //
                         .filter(warning ->
-                                StringUtils.equals(warning.getTypeName(), FakeBuildWrapper.class.getName())) //
+                                Objects.equals(warning.getTypeName(),FakeBuildWrapper.class.getName())) //
                         .count());
 
         assertEquals(
                 1,
                 converterResult.getWarnings().stream() //
-                        .filter(warning -> StringUtils.equals(warning.getTypeName(), FakeRecorder.class.getName())) //
+                        .filter(warning -> Objects.equals(warning.getTypeName(),FakeRecorder.class.getName())) //
                         .count());
 
         String groovy = converterResult.getModelASTPipelineDef().toPrettyGroovy();

--- a/declarative-pipeline-migration-assistant/src/test/java/io/jenkins/plugins/todeclarative/converter/FreestyleTest.java
+++ b/declarative-pipeline-migration-assistant/src/test/java/io/jenkins/plugins/todeclarative/converter/FreestyleTest.java
@@ -56,7 +56,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import java.util.Objects;
 import jenkins.model.BuildDiscarder;
 import jenkins.model.BuildDiscarderProperty;
 import jenkins.model.Jenkins;
@@ -618,13 +617,13 @@ public class FreestyleTest {
         assertEquals(
                 1,
                 converterResult.getWarnings().stream() //
-                        .filter(warning -> Objects.equals(warning.getTypeName(), FakeBuildWrapper.class.getName())) //
+                        .filter(warning -> FakeBuildWrapper.class.getName().equals(warning.getTypeName())) //
                         .count());
 
         assertEquals(
                 1,
                 converterResult.getWarnings().stream() //
-                        .filter(warning -> Objects.equals(warning.getTypeName(), FakeRecorder.class.getName())) //
+                        .filter(warning -> FakeRecorder.class.getName().equals(warning.getTypeName())) //
                         .count());
 
         String groovy = converterResult.getModelASTPipelineDef().toPrettyGroovy();

--- a/declarative-pipeline-migration-assistant/src/test/java/io/jenkins/plugins/todeclarative/converter/FreestyleTest.java
+++ b/declarative-pipeline-migration-assistant/src/test/java/io/jenkins/plugins/todeclarative/converter/FreestyleTest.java
@@ -303,8 +303,7 @@ public class FreestyleTest {
             FileUtils.deleteDirectory(f);
         }
         Files.createDirectories(f.toPath());
-        String workspace =
-                Functions.isWindows() ? f.getAbsolutePath().replace("\\", "\\\\") : f.getAbsolutePath();
+        String workspace = Functions.isWindows() ? f.getAbsolutePath().replace("\\", "\\\\") : f.getAbsolutePath();
         p.setCustomWorkspace(workspace);
 
         p.addProperty(new BuildDiscarderProperty(new NoOpBuildDiscarder()));
@@ -613,20 +612,19 @@ public class FreestyleTest {
         assertEquals(
                 1,
                 converterResult.getWarnings().stream() //
-                        .filter(warning -> Objects.equals(warning.getTypeName(),FakeBuilder.class.getName())) //
+                        .filter(warning -> Objects.equals(warning.getTypeName(), FakeBuilder.class.getName())) //
                         .count());
 
         assertEquals(
                 1,
                 converterResult.getWarnings().stream() //
-                        .filter(warning ->
-                                Objects.equals(warning.getTypeName(),FakeBuildWrapper.class.getName())) //
+                        .filter(warning -> Objects.equals(warning.getTypeName(), FakeBuildWrapper.class.getName())) //
                         .count());
 
         assertEquals(
                 1,
                 converterResult.getWarnings().stream() //
-                        .filter(warning -> Objects.equals(warning.getTypeName(),FakeRecorder.class.getName())) //
+                        .filter(warning -> Objects.equals(warning.getTypeName(), FakeRecorder.class.getName())) //
                         .count());
 
         String groovy = converterResult.getModelASTPipelineDef().toPrettyGroovy();

--- a/declarative-pipeline-migration-assistant/src/test/java/io/jenkins/plugins/todeclarative/converter/FreestyleTest.java
+++ b/declarative-pipeline-migration-assistant/src/test/java/io/jenkins/plugins/todeclarative/converter/FreestyleTest.java
@@ -612,7 +612,7 @@ public class FreestyleTest {
         assertEquals(
                 1,
                 converterResult.getWarnings().stream() //
-                        .filter(warning -> Objects.equals(warning.getTypeName(), FakeBuilder.class.getName())) //
+                        .filter(warning -> FakeBuilder.class.getName().equals(warning.getTypeName())) //
                         .count());
 
         assertEquals(

--- a/pom.xml
+++ b/pom.xml
@@ -70,6 +70,7 @@
     <jenkins.version>${jenkins.baseline}.1</jenkins.version>
     <revision>1.6.7</revision>
     <spotless.check.skip>false</spotless.check.skip>
+    <ban-commons-lang-2.skip>false</ban-commons-lang-2.skip>
   </properties>
 
   <dependencyManagement>


### PR DESCRIPTION
Remove the commons-lang2 API calls as Jenkins core will no longer have commons-lang2 in near future.
The usages here are simple, so replace with jdk apis.