### PR TITLE
Fix release-drafter config broken by v7 upgrade

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,2 +1,2 @@
-_extends: .github
+_extends: github:jenkinsci/.github:/.github/release-drafter.yml
 tag-template: declarative-pipeline-migration-assistant-$NEXT_MINOR_VERSION


### PR DESCRIPTION
`release-drafter v7` dropped support for `_extends: .github`; replace with the full explicit path.
* #355 (upgrade PR) - bumped to v7 in this plugin - since then, auto release must be failing in this plugin. But last release was much before that.

Failing CI run:
https://github.com/jenkinsci/declarative-pipeline-migration-assistant-plugin/actions/runs/30517736549/job/90791218340 
```
Error: Unsupported file extension: .github. Supported extensions are: json, yml, yaml
```

Found a fix done in another PR - https://github.com/jenkinsci/pipeline-stage-view-plugin/pull/422 